### PR TITLE
React.js Links vol.11

### DIFF
--- a/source/_posts/2016-08-25-reactjs-links-vol11.markdown
+++ b/source/_posts/2016-08-25-reactjs-links-vol11.markdown
@@ -58,3 +58,10 @@ ReactEurope 2016でAndroid版の事例を紹介していたReactNativeで作ら�
 ## Async Redux Actions With RxJS
 
 * http://www.slideshare.net/benlesh1/async-redux-actions-with-rxjs-react-rally-2016
+
+## React: Facebook's Functional Turn on Writing JavaScript
+
+Reactの初期の開発者であるPete Huntと、現在の開発者であるPaul O'Shannessyに対するReactに関するインタビューです。
+Reactの思想などについて語られていて、面白いです。
+
+* http://queue.acm.org/detail.cfm?id=2994373

--- a/source/_posts/2016-08-25-reactjs-links-vol11.markdown
+++ b/source/_posts/2016-08-25-reactjs-links-vol11.markdown
@@ -45,3 +45,11 @@ CSS in JSでのパターン集です。
 ReactEurope 2016でAndroid版の事例を紹介していたReactNativeで作られたExponentのiOS/Android版が公開されています。
 
 * https://github.com/exponentjs/exponent
+
+## react-history
+
+* https://github.com/ReactTraining/react-history
+
+## Animating in React
+
+* http://slides.com/sdrasner/react-rally#/

--- a/source/_posts/2016-08-25-reactjs-links-vol11.markdown
+++ b/source/_posts/2016-08-25-reactjs-links-vol11.markdown
@@ -22,3 +22,9 @@ CSS in JSでのパターン集です。
 これがmergeされると、Flowのtype annotationのためだけに`babel-plugin-transform-class-properties`を追加する必要はなくなります。
 
 * https://github.com/babel/babel/pull/3655
+
+## exponentjs/exponent
+
+ReactEurope 2016でAndroid版の事例を紹介していたReactNativeで作られたExponentのiOS/Android版が公開されています。
+
+* https://github.com/exponentjs/exponent

--- a/source/_posts/2016-08-25-reactjs-links-vol11.markdown
+++ b/source/_posts/2016-08-25-reactjs-links-vol11.markdown
@@ -9,3 +9,16 @@ categories: react.js react-links
 これはReactに関する記事や気になるissueなどのリンクを紹介する記事です。
 
 <!-- more -->
+
+## PATTERNS FOR STYLE COMPOSITION IN REACT
+
+CSS in JSでのパターン集です。
+
+* http://jxnblk.com/writing/posts/patterns-for-style-composition-in-react/
+
+## Strip flow-only class props without needing transform-class-properties. #3655 (Babel)
+
+`babel-plugin-transform-flow-strip-types`でtype annotationのためだけに使われているclass propertiesを削除するというPRです。
+これがmergeされると、Flowのtype annotationのためだけに`babel-plugin-transform-class-properties`を追加する必要はなくなります。
+
+* https://github.com/babel/babel/pull/3655

--- a/source/_posts/2016-08-25-reactjs-links-vol11.markdown
+++ b/source/_posts/2016-08-25-reactjs-links-vol11.markdown
@@ -49,13 +49,24 @@ ReactEurope 2016でAndroid版の事例を紹介していたReactNativeで作ら�
 
 ## react-history
 
+`history`をラップしたようなReactComponentです。
+`react-router`のv4はこれを使うというような話もあり、あいかわらず落ち着かない感じです...。
+
 * https://github.com/ReactTraining/react-history
 
 ## Animating in React
 
+ReactでのAnimationの方法についてのスライドです。
+codepenによるサンプルも多く埋め込まれており、とてもわかりやすいです。
+
+CSS、DOM、SVG、Canvasなどによるアプローチの比較や、react-motionなどライブラリーに関する解説もあり、アニメーションで悩んでいる人にはおすすめのスライドです。
+
 * http://slides.com/sdrasner/react-rally#/
 
 ## Async Redux Actions With RxJS
+
+NetflixのエンジニアでRxJSの開発者であるBen Leshによる、redux-observableを使ってReduxとRxJSを組み合わせる話です。
+なぜReduxにRxJSを組み合わせる必要があるのか、redux-observableにあるEpicとは何なのかということがわかりやすく解説されています。
 
 * http://www.slideshare.net/benlesh1/async-redux-actions-with-rxjs-react-rally-2016
 

--- a/source/_posts/2016-08-25-reactjs-links-vol11.markdown
+++ b/source/_posts/2016-08-25-reactjs-links-vol11.markdown
@@ -10,6 +10,23 @@ categories: react.js react-links
 
 <!-- more -->
 
+## React Core Meeting Notes
+
+7/21, 28, 8/4のMeeting Noteがまとめて公開されました。
+
+`React.createClass`のES classes化については、引き続き進められているようで、すでに80%がES classesになったそうです。
+Public Class Fieldsがstage2になったことも紹介されています。
+
+その他には、`create-react-app`をリリースしたことや、そこでのJestサポートについても紹介されています。
+また7/28のMeeting Noteでは、Reconcilerの位置付けについて解説されています。Reconcilerはrendererに属するものであり、react本体にはComponentやReactElementを作成する部分のみが含まれているという形です。
+それにより、新しいReactFiberのReconcilerの導入もすでにあるReact Componentに手を入れることなくできるとしています。
+
+（Reactの中では、完全にrenderer毎にコードが分かれているわけではなくて、共通化されている部分もありますが）
+
+* https://github.com/reactjs/core-notes/blob/master/2016-07/july-21.md
+* https://github.com/reactjs/core-notes/blob/master/2016-07/july-28.md
+* https://github.com/reactjs/core-notes/blob/master/2016-08/august-04.md
+
 ## PATTERNS FOR STYLE COMPOSITION IN REACT
 
 CSS in JSでのパターン集です。

--- a/source/_posts/2016-08-25-reactjs-links-vol11.markdown
+++ b/source/_posts/2016-08-25-reactjs-links-vol11.markdown
@@ -1,0 +1,11 @@
+---
+layout: post
+title: "React.js Links vol.11"
+date: 2016-08-25 14:13:04 +0900
+comments: true
+categories: react.js react-links
+---
+
+これはReactに関する記事や気になるissueなどのリンクを紹介する記事です。
+
+<!-- more -->

--- a/source/_posts/2016-08-25-reactjs-links-vol11.markdown
+++ b/source/_posts/2016-08-25-reactjs-links-vol11.markdown
@@ -12,7 +12,7 @@ categories: react.js react-links
 
 ## React Core Meeting Notes
 
-7/21, 28, 8/4のMeeting Noteがまとめて公開されました。
+7/21, 28, 8/4, 25のMeeting Noteがまとめて公開されました。
 
 `React.createClass`のES classes化については、引き続き進められているようで、すでに80%がES classesになったそうです。
 Public Class Fieldsがstage2になったことも紹介されています。
@@ -26,6 +26,7 @@ Public Class Fieldsがstage2になったことも紹介されています。
 * https://github.com/reactjs/core-notes/blob/master/2016-07/july-21.md
 * https://github.com/reactjs/core-notes/blob/master/2016-07/july-28.md
 * https://github.com/reactjs/core-notes/blob/master/2016-08/august-04.md
+* https://github.com/reactjs/core-notes/blob/master/2016-08/august-25.md
 
 ## PATTERNS FOR STYLE COMPOSITION IN REACT
 

--- a/source/_posts/2016-08-25-reactjs-links-vol11.markdown
+++ b/source/_posts/2016-08-25-reactjs-links-vol11.markdown
@@ -53,3 +53,7 @@ ReactEurope 2016でAndroid版の事例を紹介していたReactNativeで作ら�
 ## Animating in React
 
 * http://slides.com/sdrasner/react-rally#/
+
+## Async Redux Actions With RxJS
+
+* http://www.slideshare.net/benlesh1/async-redux-actions-with-rxjs-react-rally-2016

--- a/source/_posts/2016-09-08-reactjs-links-vol11d.markdown
+++ b/source/_posts/2016-09-08-reactjs-links-vol11d.markdown
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: "React.js Links vol.11"
-date: 2016-08-25 14:13:04 +0900
+date: 2016-09-07 19:26:04 +0900
 comments: true
 categories: react.js react-links
 ---


### PR DESCRIPTION
will be published around 25 Aug.