### PR TITLE
fix: code style and image

### DIFF
--- a/lib/markdown.ts
+++ b/lib/markdown.ts
@@ -50,7 +50,7 @@ export async function getPostData(id: string) {
 
   // Use remark to convert markdown into HTML string
   const processedContent = await remark()
-    .use(html)
+    .use(html, { sanitize: false })
     .use(linkify(/https?:\/\/[^\s]*/))
     .use(prism)
     .process(matterResult.content);


### PR DESCRIPTION
`remark-html` has changed the default option in its patch release.
https://github.com/remarkjs/remark-html/releases/tag/13.0.2